### PR TITLE
[SLOP(gpt-5)] feat: repair stale stack comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,15 @@ version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
 
+# `cargo install --path .` installs each binary target listed here.
+[[bin]]
+name = "forklift"
+path = "src/main.rs"
+
+[[bin]]
+name = "forklift-ui-mock"
+path = "src/bin/forklift-ui-mock.rs"
+
 [dependencies]
 anyhow = "1.0.98"
 clap = { version = "4.5.38", features = ["derive"] }

--- a/src/bin/forklift-ui-mock.rs
+++ b/src/bin/forklift-ui-mock.rs
@@ -70,7 +70,7 @@ fn run_submit_actions_scenario() -> Result<()> {
     let fixture = Fixture::new("submit-actions")?;
     fixture.seed_submit_actions()?;
 
-    eprintln!("ui-scenario: submit-actions");
+    eprintln!("forklift-ui-mock: submit-actions");
     eprintln!("fixture: {}", fixture.root.display());
     eprintln!("running: forklift submit");
 
@@ -90,7 +90,7 @@ fn run_sync_only_scenario() -> Result<()> {
     let fixture = Fixture::new("sync-only")?;
     fixture.seed_sync_stack()?;
 
-    eprintln!("ui-scenario: sync-only");
+    eprintln!("forklift-ui-mock: sync-only");
     eprintln!("fixture: {}", fixture.root.display());
     eprintln!("running: forklift sync");
 
@@ -110,7 +110,7 @@ fn run_sync_submit_scenario() -> Result<()> {
     let fixture = Fixture::new("sync-submit")?;
     fixture.seed_submit_actions()?;
 
-    eprintln!("ui-scenario: sync-submit");
+    eprintln!("forklift-ui-mock: sync-submit");
     eprintln!("fixture: {}", fixture.root.display());
     eprintln!("running: forklift sync --submit");
 
@@ -130,7 +130,7 @@ fn run_merge_scenario(scenario: Scenario) -> Result<()> {
     let fixture = Fixture::new(scenario.name())?;
     fixture.seed_two_pr_merge(scenario)?;
 
-    eprintln!("ui-scenario: {}", scenario.name());
+    eprintln!("forklift-ui-mock: {}", scenario.name());
     eprintln!("fixture: {}", fixture.root.display());
     eprintln!("running: forklift merge --admin");
 
@@ -373,8 +373,8 @@ impl Fixture {
             .args(args)
             .current_dir(&self.workspace)
             .env("PATH", format!("{}:{old_path}", self.bin_dir.display()))
-            .env("UI_SCENARIO_ROOT", &self.root)
-            .env("UI_SCENARIO_WORKSPACE", &self.workspace)
+            .env("FORKLIFT_UI_MOCK_ROOT", &self.root)
+            .env("FORKLIFT_UI_MOCK_WORKSPACE", &self.workspace)
             .stdin(Stdio::inherit())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit());
@@ -535,7 +535,10 @@ fn write_executable(path: &Path, contents: &str) -> Result<()> {
 
 fn unique_dir(name: &str) -> Result<PathBuf> {
     let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
-    let path = env::temp_dir().join(format!("forklift-ui-{name}-{}-{nanos}", std::process::id()));
+    let path = env::temp_dir().join(format!(
+        "forklift-ui-mock-{name}-{}-{nanos}",
+        std::process::id()
+    ));
     fs::create_dir_all(&path)?;
     Ok(path)
 }
@@ -563,8 +566,8 @@ import sys
 import time
 from pathlib import Path
 
-root = Path(os.environ["UI_SCENARIO_ROOT"])
-workspace = Path(os.environ["UI_SCENARIO_WORKSPACE"])
+root = Path(os.environ["FORKLIFT_UI_MOCK_ROOT"])
+workspace = Path(os.environ["FORKLIFT_UI_MOCK_WORKSPACE"])
 args = sys.argv[1:]
 
 with (root / "gh-requests.jsonl").open("a") as fh:

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::process;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use std::io::IsTerminal;
+use std::io::{self, IsTerminal, Write};
 use std::sync::OnceLock;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -348,7 +348,7 @@ const STACK_RECORD_SEPARATOR: char = '\x1e';
 const STACK_LOG_TEMPLATE: &str = "json(change_id) ++ \"\\x1f\" ++ json(commit_id) ++ \"\\x1f\" ++ json(parents.map(|c| c.commit_id())) ++ \"\\x1f\" ++ json(description.first_line()) ++ \"\\x1f\" ++ json(description) ++ \"\\x1f\" ++ json(empty) ++ \"\\x1f\" ++ json(conflict) ++ \"\\x1e\"";
 const PR_JSON_FIELDS: &str = "number,state,headRefName,baseRefName,headRefOid,baseRefOid,title,body,createdAt,id,author,headRepository";
 const MERGE_PR_JSON_FIELDS: &str = "number,state,headRefName,baseRefName,headRefOid,baseRefOid,title,body,createdAt,isDraft,reviewDecision,mergeable,mergeStateStatus,statusCheckRollup,autoMergeRequest";
-const PR_API_JQ: &str = "{number,state,headRefName:.head.ref,baseRefName:.base.ref,headRefOid:.head.sha,baseRefOid:.base.sha,title,body,createdAt:.created_at,id:.node_id,headRepository:{id:(.head.repo.id|tostring),node_id:.head.repo.node_id,nameWithOwner:.head.repo.full_name},baseRepository:{id:(.base.repo.id|tostring),node_id:.base.repo.node_id,nameWithOwner:.base.repo.full_name},author:{login:.user.login}}";
+const PR_API_JQ: &str = "{number,state,merged,headRefName:.head.ref,baseRefName:.base.ref,headRefOid:.head.sha,baseRefOid:.base.sha,title,body,createdAt:.created_at,id:.node_id,headRepository:{id:(.head.repo.id|tostring),node_id:.head.repo.node_id,nameWithOwner:.head.repo.full_name},baseRepository:{id:(.base.repo.id|tostring),node_id:.base.repo.node_id,nameWithOwner:.base.repo.full_name},author:{login:.user.login}}";
 const STACK_COMMENT_MARKER: &str = "<!-- stack:v1 -->";
 const STACK_COMMENT_JQ: &str =
     ".[] | {id,body,userLogin:.user.login,updatedAt:.updated_at} | @json";
@@ -386,6 +386,7 @@ enum Commands {
     Sync(SyncOptions),
     Merge(MergeOptions),
     Get(GetOptions),
+    Repair(RepairOptions),
     Unfreeze(UnfreezeOptions),
     Status(StatusOptions),
     /// Open a pull request in your browser.
@@ -399,6 +400,7 @@ impl Commands {
             Self::Sync(_) => "sync",
             Self::Merge(_) => "merge",
             Self::Get(_) => "get",
+            Self::Repair(_) => "repair",
             Self::Unfreeze(_) => "unfreeze",
             Self::Status(_) => "status",
             Self::Pr(_) => "pr",
@@ -443,6 +445,15 @@ struct MergeOptions {
 #[derive(Debug, Args)]
 struct GetOptions {
     target: String,
+}
+
+#[derive(Debug, Args)]
+struct RepairOptions {
+    target: String,
+
+    /// Apply the repair without prompting for confirmation.
+    #[arg(short, long)]
+    yes: bool,
 }
 
 #[derive(Debug, Args)]
@@ -774,6 +785,27 @@ fn run_command(cli: Cli, runner: &impl CommandRunner, cwd: &str) -> Result<()> {
                     &format!(
                         "get — {} PRs fetched, {} cache entries written",
                         summary.prs, summary.cache_entries
+                    ),
+                );
+            }
+        }
+        Commands::Repair(options) => {
+            let summary =
+                repair_stack_comments(runner, &config, &options.target, options.yes, diagnostics)?;
+            if cli.dry_run {
+                ui_progress(
+                    "Finished",
+                    &format!(
+                        "repair (dry run) — {} open PRs, {} merged PRs to prune, {} comments planned",
+                        summary.open_prs, summary.pruned_merged_prs, summary.comments_changed
+                    ),
+                );
+            } else {
+                ui_progress(
+                    "Finished",
+                    &format!(
+                        "repair — {} open PRs, {} merged PRs pruned, {} comments changed",
+                        summary.open_prs, summary.pruned_merged_prs, summary.comments_changed
                     ),
                 );
             }
@@ -2016,6 +2048,43 @@ struct GetSummary {
     cache_entries: usize,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RepairSummary {
+    open_prs: usize,
+    pruned_merged_prs: usize,
+    comments_changed: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RepairPlan {
+    open_prs: Vec<GhPr>,
+    pruned_merged_prs: Vec<u64>,
+}
+
+#[derive(Debug, Clone)]
+enum RepairAction {
+    UpsertStackComment {
+        pr_number: u64,
+        removed_prs: Vec<u64>,
+        body: String,
+    },
+}
+
+impl RepairAction {
+    fn describe(&self) -> String {
+        match self {
+            Self::UpsertStackComment {
+                pr_number,
+                removed_prs,
+                ..
+            } => {
+                let removed = repair_pr_list(removed_prs);
+                format!("update stack comment on PR #{pr_number} to remove {removed}")
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct StatusReport {
     repo: String,
@@ -2322,6 +2391,319 @@ fn get_stack(
         fetched_branches: pr_count,
         cache_entries: cache_entries,
     })
+}
+
+#[tracing::instrument(skip_all, fields(target = target))]
+fn repair_stack_comments(
+    runner: &impl CommandRunner,
+    config: &AppConfig,
+    target: &str,
+    yes: bool,
+    diagnostics: Diagnostics,
+) -> Result<RepairSummary> {
+    diagnostics.phase("resolve-github");
+    let mut github = GitHubContext::resolve(runner)
+        .map_err(|error| phase_error("resolve-github", "github", error))?;
+    let target = parse_get_target(target, &github.repo)?;
+    github.repo = target.repo().to_owned();
+
+    diagnostics.phase("resolve-stack-comment");
+    let target_pr = resolve_get_target_pr(runner, &github, target)?;
+    if !target_pr.state.eq_ignore_ascii_case("OPEN") {
+        bail!(
+            "repair target PR #{} is {}; choose an open PR whose stack comment should be repaired",
+            target_pr.number,
+            target_pr.state
+        );
+    }
+    let comment = latest_stack_comment(runner, &github, target_pr.number, "repair")?;
+    let mut pr_numbers = comment
+        .as_ref()
+        .map(|comment| parse_stack_pr_numbers(&comment.body))
+        .unwrap_or_default();
+    pr_numbers.reverse();
+    if pr_numbers.is_empty() {
+        pr_numbers.push(target_pr.number);
+    }
+    if !pr_numbers.contains(&target_pr.number) {
+        bail!(
+            "stack comment for PR #{} did not include the target PR",
+            target_pr.number
+        );
+    }
+
+    diagnostics.phase("resolve-prs");
+    let plan = plan_stack_comment_repair(runner, config, &github, target_pr.number, pr_numbers)?;
+    let actions = repair_actions(&github, config, &plan);
+    print_repair_action_plan(&plan, &actions, diagnostics);
+
+    let mut summary = RepairSummary {
+        open_prs: plan.open_prs.len(),
+        pruned_merged_prs: plan.pruned_merged_prs.len(),
+        comments_changed: 0,
+    };
+    if diagnostics.dry_run {
+        summary.comments_changed = actions.len();
+        return Ok(summary);
+    }
+    if actions.is_empty() {
+        return Ok(summary);
+    }
+    confirm_repair_stack_comments(&plan, &actions, target_pr.number, yes)?;
+
+    diagnostics.phase("stack-comments");
+    for action in &actions {
+        if execute_repair_action(runner, &github, action, diagnostics)? {
+            summary.comments_changed += 1;
+        }
+    }
+
+    diagnostics.phase("repair-validate");
+    validate_repair_result(runner, config, &github, target_pr.number, &plan)?;
+
+    Ok(summary)
+}
+
+#[tracing::instrument(skip_all)]
+fn repair_actions(
+    github: &GitHubContext,
+    config: &AppConfig,
+    plan: &RepairPlan,
+) -> Vec<RepairAction> {
+    if plan.pruned_merged_prs.is_empty() {
+        return Vec::new();
+    }
+
+    plan.open_prs
+        .iter()
+        .map(|pr| RepairAction::UpsertStackComment {
+            pr_number: pr.number,
+            removed_prs: plan.pruned_merged_prs.clone(),
+            body: repaired_stack_comment_body(github, &plan.open_prs, pr.number, &config.trunk),
+        })
+        .collect()
+}
+
+#[tracing::instrument(skip_all)]
+fn print_repair_action_plan(plan: &RepairPlan, actions: &[RepairAction], diagnostics: Diagnostics) {
+    render_repair_action_plan(plan, actions, |line| diagnostics.plan_line(line));
+}
+
+fn render_repair_action_plan(
+    plan: &RepairPlan,
+    actions: &[RepairAction],
+    mut emit: impl FnMut(&str),
+) {
+    let pruned = repair_pr_list(&plan.pruned_merged_prs);
+
+    emit("");
+    emit("problems:");
+    emit(&format!(
+        "  merged PRs still listed in stack comment: {pruned}"
+    ));
+    emit("");
+    emit("actions:");
+    if actions.is_empty() {
+        emit("  <none>");
+    } else {
+        for (index, action) in actions.iter().enumerate() {
+            emit(&format!("  {}. {}", index + 1, action.describe()));
+        }
+        emit(&format!(
+            "  {}. revalidate repaired stack comment topology",
+            actions.len() + 1
+        ));
+    }
+}
+
+fn repair_pr_list(numbers: &[u64]) -> String {
+    if numbers.is_empty() {
+        "<none>".to_owned()
+    } else {
+        numbers
+            .iter()
+            .map(|number| format!("#{number}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+fn print_repair_plan_line(line: &str) {
+    if ui_color_enabled() {
+        if let Some((label, rest)) = line.split_once(':') {
+            match label.trim() {
+                "problems" => {
+                    eprintln!("{}:{rest}", label.red().bold());
+                    return;
+                }
+                "actions" => {
+                    eprintln!("{}:{rest}", label.cyan().bold());
+                    return;
+                }
+                _ => {}
+            }
+        }
+    }
+    eprintln!("{line}");
+}
+
+#[tracing::instrument(skip_all)]
+fn execute_repair_action(
+    runner: &impl CommandRunner,
+    github: &GitHubContext,
+    action: &RepairAction,
+    diagnostics: Diagnostics,
+) -> Result<bool> {
+    match action {
+        RepairAction::UpsertStackComment {
+            pr_number, body, ..
+        } => match upsert_stack_comment(runner, github, *pr_number, "repair", body, diagnostics)? {
+            StackCommentAction::Created(_) | StackCommentAction::Updated(_, _) => Ok(true),
+            StackCommentAction::Unchanged(_) => Ok(false),
+        },
+    }
+}
+
+#[tracing::instrument(skip_all)]
+fn confirm_repair_stack_comments(
+    plan: &RepairPlan,
+    actions: &[RepairAction],
+    target_pr_number: u64,
+    yes: bool,
+) -> Result<()> {
+    if yes {
+        return Ok(());
+    }
+    render_repair_action_plan(plan, actions, |line| print_repair_plan_line(line));
+    eprintln!();
+    if !io::stdin().is_terminal() {
+        return Err(anyhow::Error::new(
+            CliError::new("repair requires confirmation")
+                .reason("repair would update GitHub stack comments, but stdin is not a terminal")
+                .resolution(format!(
+                    "rerun with `forklift repair {target_pr_number} --yes`"
+                ))
+                .detail("target", format!("#{target_pr_number}"))
+                .detail("comments", plan.open_prs.len()),
+        ));
+    }
+    eprint!("Apply repair? [y/N] ");
+    io::stderr()
+        .flush()
+        .context("flush repair confirmation prompt")?;
+
+    let mut answer = String::new();
+    io::stdin()
+        .read_line(&mut answer)
+        .context("read repair confirmation")?;
+    if matches!(answer.trim(), "y" | "Y" | "yes" | "YES" | "Yes") {
+        Ok(())
+    } else {
+        Err(anyhow::Error::new(
+            CliError::new("repair cancelled")
+                .reason("confirmation was not accepted")
+                .resolution(format!(
+                    "rerun with `forklift repair {target_pr_number} --yes`"
+                )),
+        ))
+    }
+}
+
+#[tracing::instrument(skip_all)]
+fn validate_repair_result(
+    runner: &impl CommandRunner,
+    config: &AppConfig,
+    github: &GitHubContext,
+    target_pr_number: u64,
+    plan: &RepairPlan,
+) -> Result<()> {
+    let comment = latest_stack_comment(runner, github, target_pr_number, "repair-validate")?
+        .with_context(|| format!("repaired PR #{target_pr_number} has no stack comment"))?;
+    let mut pr_numbers = parse_stack_pr_numbers(&comment.body);
+    pr_numbers.reverse();
+    let validation_plan =
+        plan_stack_comment_repair(runner, config, github, target_pr_number, pr_numbers)
+            .context("re-run repair detection on repaired stack comment")?;
+    if !validation_plan.pruned_merged_prs.is_empty() {
+        bail!(
+            "repair validation failed: repaired stack comment still lists merged PR(s): {}",
+            repair_pr_list(&validation_plan.pruned_merged_prs)
+        );
+    }
+
+    let expected = plan.open_prs.iter().map(|pr| pr.number).collect::<Vec<_>>();
+    let actual = validation_plan
+        .open_prs
+        .iter()
+        .map(|pr| pr.number)
+        .collect::<Vec<_>>();
+    if actual != expected {
+        bail!(
+            "repair validation failed: stack comment lists {:?}, expected {:?}",
+            actual,
+            expected,
+        );
+    }
+
+    Ok(())
+}
+
+#[tracing::instrument(skip_all)]
+fn plan_stack_comment_repair(
+    runner: &impl CommandRunner,
+    config: &AppConfig,
+    github: &GitHubContext,
+    target_pr_number: u64,
+    pr_numbers: Vec<u64>,
+) -> Result<RepairPlan> {
+    let mut seen = HashSet::new();
+    let mut open_prs = Vec::new();
+    let mut pruned_merged_prs = Vec::new();
+    for pr_number in pr_numbers {
+        if !seen.insert(pr_number) {
+            bail!("stack comment listed PR #{} more than once", pr_number);
+        }
+        let pr = fetch_pr_by_number(runner, github, "repair", pr_number)?;
+        validate_get_pr_metadata(github, &pr)?;
+        if pr.state.eq_ignore_ascii_case("OPEN") {
+            open_prs.push(pr);
+        } else if pr_was_merged(&pr) {
+            pruned_merged_prs.push(pr.number);
+        } else {
+            return Err(anyhow::Error::new(
+                CliError::new("cannot repair stack comment automatically")
+                    .reason(format!(
+                        "PR #{} is {} but not merged",
+                        pr.number, pr.state
+                    ))
+                    .resolution(format!(
+                        "reopen or merge PR #{}, or remove it from the stack comment manually, then run `forklift repair {target_pr_number}`",
+                        pr.number
+                    ))
+                    .detail("target", format!("#{target_pr_number}"))
+                    .detail("pr", format!("#{}", pr.number))
+                    .detail("state", &pr.state),
+            ));
+        }
+    }
+
+    if !open_prs.iter().any(|pr| pr.number == target_pr_number) {
+        bail!(
+            "repair would remove target PR #{}; choose an open PR still in the stack",
+            target_pr_number
+        );
+    }
+    validate_get_pr_stack(config, github, target_pr_number, &open_prs)?;
+
+    Ok(RepairPlan {
+        open_prs,
+        pruned_merged_prs,
+    })
+}
+
+#[tracing::instrument(level = "trace", skip_all, fields(pr = pr.number))]
+fn pr_was_merged(pr: &GhPr) -> bool {
+    pr.merged || pr.state.eq_ignore_ascii_case("MERGED")
 }
 
 #[tracing::instrument(skip_all, fields(target = target))]
@@ -6254,6 +6636,75 @@ fn stack_comment_body_with_frozen(
     body
 }
 
+#[tracing::instrument(skip_all, fields(current_pr = current_pr_number))]
+fn repaired_stack_comment_body(
+    github: &GitHubContext,
+    prs: &[GhPr],
+    current_pr_number: u64,
+    trunk: &str,
+) -> String {
+    let mut body = format!("{STACK_COMMENT_MARKER}\nStack for {}\n\n", github.repo);
+
+    for pr in prs.iter().rev() {
+        push_repaired_stack_comment_line(
+            &mut body,
+            &github.repo,
+            pr,
+            pr.number == current_pr_number,
+        );
+    }
+
+    body.push_str(&format!("- {trunk}\n"));
+    body.push('\n');
+    if prs.iter().any(|pr| pr.number == current_pr_number) {
+        body.push_str(&format!(
+            "Check out this stack: `forklift get {}`\n",
+            current_pr_number
+        ));
+    }
+    body.push_str("Pull/update this stack: `forklift sync`\n");
+    body.push_str("Publish local edits: `forklift submit`\n");
+    body.push_str("Merge when ready: `forklift merge`\n");
+
+    body
+}
+
+#[tracing::instrument(level = "trace", skip_all, fields(pr = pr.number))]
+fn push_repaired_stack_comment_line(body: &mut String, repo: &str, pr: &GhPr, is_current: bool) {
+    let label = format!(
+        "[{} #{}]({})",
+        markdown_link_label(&pr.title),
+        pr.number,
+        github_pr_url(repo, pr.number),
+    );
+    let label = if is_current {
+        format!("**{label}**")
+    } else {
+        label
+    };
+    let current_marker = if is_current { " 👈" } else { "" };
+    let created_date = created_date_fragment(&pr.created_at);
+    body.push_str(&format!(
+        "- {} _{}_{}{}\n",
+        label,
+        stack_comment_change_hint(&pr.head_ref_name),
+        created_date,
+        current_marker
+    ));
+}
+
+#[tracing::instrument(level = "trace", skip_all)]
+fn stack_comment_change_hint(head_branch: &str) -> String {
+    let last = head_branch.rsplit('/').next().unwrap_or(head_branch);
+    let mut parts = last.rsplit('-');
+    let suffix = parts.next().unwrap_or(last);
+    if suffix.chars().all(|ch| ch.is_ascii_digit()) {
+        parts.next().unwrap_or(suffix).to_owned()
+    } else {
+        suffix.to_owned()
+    }
+}
+
 #[tracing::instrument(level = "trace", skip_all, fields(change = %change_id))]
 fn push_stack_comment_line(
     body: &mut String,
@@ -7144,6 +7595,8 @@ fn lookup_open_pr_by_head_branch(
 struct GhPr {
     number: u64,
     state: String,
+    #[serde(default)]
+    merged: bool,
     #[serde(default)]
     id: String,
     #[serde(rename = "headRefName")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
-use std::fmt::Display;
+use std::error::Error;
+use std::fmt::{self, Display};
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::process;
@@ -606,14 +607,7 @@ fn run(cli: Cli, runner: &impl CommandRunner) -> Result<()> {
         Ok(()) => tracing::debug!(command = command_name, "command complete"),
         Err(error) => {
             tracing::error!(command = command_name, error = %error, "command failed");
-            let (headline, hint) = humanize_error(&error.to_string());
-            ui_error(&headline);
-            if let Some(hint) = hint {
-                ui_hint(&format!("try `{hint}`"));
-            }
-            if let Some(path) = trace_log.path() {
-                eprintln!("debug log: {}", path.display());
-            }
+            render_cli_error(error, trace_log.path());
         }
     }
 
@@ -830,9 +824,239 @@ fn run_command(cli: Cli, runner: &impl CommandRunner, cwd: &str) -> Result<()> {
 
 #[tracing::instrument(skip_all)]
 fn phase_error(phase: &str, object: impl Display, error: anyhow::Error) -> anyhow::Error {
-    anyhow!(
-        "phase={phase} object={object} error={error} safe-next-command=`forklift submit --dry-run`"
-    )
+    let object = object.to_string();
+    let inner = diagnostic_from_error(&error);
+    let mut cli_error = CliError::new(phase_summary(phase, &object))
+        .reason(reason_from_error(&error, &inner))
+        .resolution(inner.resolution.unwrap_or_else(|| {
+            "run `forklift submit --dry-run` to preview the stack state".to_owned()
+        }))
+        .detail("phase", phase)
+        .detail("object", object);
+    cli_error.details.extend(inner.details);
+    anyhow::Error::new(cli_error)
+}
+
+fn reason_from_error(error: &anyhow::Error, diagnostic: &CliError) -> String {
+    if error.chain().count() > 1 {
+        return format!("{error:#}");
+    }
+    diagnostic
+        .reason
+        .clone()
+        .unwrap_or_else(|| diagnostic.message.clone())
+}
+
+#[derive(Debug, Clone)]
+struct CliError {
+    message: String,
+    reason: Option<String>,
+    resolution: Option<String>,
+    details: Vec<(&'static str, String)>,
+}
+
+impl CliError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            reason: None,
+            resolution: None,
+            details: Vec::new(),
+        }
+    }
+
+    fn reason(mut self, reason: impl Into<String>) -> Self {
+        let reason = reason.into();
+        if !reason.trim().is_empty() {
+            self.reason = Some(reason);
+        }
+        self
+    }
+
+    fn resolution(mut self, resolution: impl Into<String>) -> Self {
+        let resolution = resolution.into();
+        if !resolution.trim().is_empty() {
+            self.resolution = Some(resolution);
+        }
+        self
+    }
+
+    fn detail(mut self, key: &'static str, value: impl Display) -> Self {
+        let value = value.to_string();
+        if !value.trim().is_empty() {
+            self.details.push((key, value));
+        }
+        self
+    }
+}
+
+impl Display for CliError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for CliError {}
+
+fn phase_summary(phase: &str, object: &str) -> String {
+    match phase {
+        "resolve-config" => "could not resolve configuration".to_owned(),
+        "startup-config" => "could not prepare jj config".to_owned(),
+        "resolve-stack" => format!("could not resolve stack `{object}`"),
+        "resolve-merge-target" => format!("could not resolve merge target `{object}`"),
+        "merge-refresh-above" => format!("could not refresh stack above `{object}`"),
+        "resolve-github" => format!("could not resolve GitHub context for `{object}`"),
+        "resolve-pr" => format!("could not resolve PR for `{object}`"),
+        "open-pr" => format!("could not open PR URL `{object}`"),
+        "status" => format!("could not build status for `{object}`"),
+        _ => format!("failed during {phase}"),
+    }
+}
+
+fn render_cli_error(error: &anyhow::Error, debug_log: Option<&Path>) {
+    let mut diagnostic = diagnostic_from_error(error);
+    if let Some(path) = debug_log {
+        diagnostic
+            .details
+            .retain(|(key, _)| *key != "debug log" && *key != "log");
+        diagnostic
+            .details
+            .push(("debug log", path.display().to_string()));
+    }
+
+    print_error_line(&diagnostic.message);
+    print_section("reason", diagnostic.reason.as_deref());
+    print_section("resolution", diagnostic.resolution.as_deref());
+    print_details(&diagnostic.details);
+}
+
+fn diagnostic_from_error(error: &anyhow::Error) -> CliError {
+    for cause in error.chain() {
+        if let Some(cli_error) = cause.downcast_ref::<CliError>() {
+            return cli_error.clone();
+        }
+    }
+
+    let mut chain = error.chain();
+    let message = chain
+        .next()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "command failed".to_owned());
+    let mut diagnostic = diagnostic_from_message(&message);
+    let causes = chain.map(ToString::to_string).collect::<Vec<_>>();
+    if diagnostic.reason.is_none() && !causes.is_empty() {
+        diagnostic.reason = Some(causes.join(": "));
+    }
+    diagnostic
+}
+
+fn diagnostic_from_message(message: &str) -> CliError {
+    let mut diagnostic = if let Some(phase) = structured_value(message, "phase=") {
+        let object = structured_value(message, "object=").unwrap_or_default();
+        CliError::new(phase_summary(&phase, &object)).detail("phase", phase)
+    } else if message.contains("failed-command=`") {
+        CliError::new("command failed")
+    } else if message.contains("failed-api=`") {
+        CliError::new("GitHub API request failed")
+    } else {
+        CliError::new(message.trim())
+    };
+
+    if let Some(object) = structured_value(message, "object=") {
+        diagnostic = diagnostic.detail("object", object);
+    }
+    if let Some(command) = backtick_value(message, "failed-command=`") {
+        diagnostic = diagnostic.detail("command", command);
+    }
+    if let Some(api) = backtick_value(message, "failed-api=`") {
+        diagnostic = diagnostic.detail("api", api);
+    }
+    if let Some(reason) = structured_error_reason(message) {
+        diagnostic = diagnostic.reason(reason);
+    }
+    if let Some(command) = backtick_value(message, "safe-next-command=`") {
+        diagnostic = diagnostic.resolution(format!("run `{command}`"));
+    }
+
+    diagnostic
+}
+
+fn structured_error_reason(message: &str) -> Option<String> {
+    let start = message.find("error=")? + "error=".len();
+    let mut end = message.len();
+    for marker in [
+        " safe-next-command=",
+        " failed-command=",
+        " failed-api=",
+        " phase=",
+        " object=",
+    ] {
+        if let Some(offset) = message[start..].find(marker) {
+            end = end.min(start + offset);
+        }
+    }
+    let reason = message[start..end].trim();
+    (!reason.is_empty()).then(|| reason.to_owned())
+}
+
+fn structured_value(message: &str, key: &str) -> Option<String> {
+    let start = message.find(key)? + key.len();
+    let value = message[start..]
+        .split_once(' ')
+        .map(|(value, _)| value)
+        .unwrap_or(&message[start..])
+        .trim();
+    (!value.is_empty()).then(|| value.trim_matches('`').to_owned())
+}
+
+fn backtick_value(message: &str, key: &str) -> Option<String> {
+    let start = message.find(key)? + key.len();
+    let value = message[start..].split_once('`')?.0.trim();
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
+fn print_error_line(message: &str) {
+    if ui_color_enabled() {
+        eprintln!("{} {}", "error:".red().bold(), message);
+    } else {
+        eprintln!("error: {message}");
+    }
+}
+
+fn print_section(label: &str, value: Option<&str>) {
+    let Some(value) = value else {
+        return;
+    };
+    eprintln!();
+    if ui_color_enabled() {
+        eprintln!("{}", format!("{label}:").cyan().bold());
+    } else {
+        eprintln!("{label}:");
+    }
+    for line in value.lines() {
+        eprintln!("  {line}");
+    }
+}
+
+fn print_details(details: &[(&'static str, String)]) {
+    if details.is_empty() {
+        return;
+    }
+    eprintln!();
+    if ui_color_enabled() {
+        eprintln!("{}", "details:".cyan().bold());
+    } else {
+        eprintln!("details:");
+    }
+    let width = details
+        .iter()
+        .map(|(key, _)| key.len() + 1)
+        .max()
+        .unwrap_or(0);
+    for (key, value) in details {
+        let label = format!("{key}:");
+        eprintln!("  {label:width$} {value}");
+    }
 }
 
 /// Turns an internal structured error string (the `phase=… object=… error=…

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -414,6 +414,28 @@ impl TestRepo {
         self.write_gh_state(&state)
     }
 
+    pub fn set_pr_state(&self, pr_number: u64, state: &str) -> anyhow::Result<()> {
+        let mut gh_state = self.read_gh_state()?;
+        let prs = gh_state["prs"].as_array_mut().expect("prs array");
+        let pr = prs
+            .iter_mut()
+            .find(|pr| pr["number"] == json!(pr_number))
+            .with_context(|| format!("PR #{pr_number} not found in fake gh state"))?;
+        pr["state"] = json!(state);
+        self.write_gh_state(&gh_state)
+    }
+
+    pub fn set_pr_merged(&self, pr_number: u64, merged: bool) -> anyhow::Result<()> {
+        let mut gh_state = self.read_gh_state()?;
+        let prs = gh_state["prs"].as_array_mut().expect("prs array");
+        let pr = prs
+            .iter_mut()
+            .find(|pr| pr["number"] == json!(pr_number))
+            .with_context(|| format!("PR #{pr_number} not found in fake gh state"))?;
+        pr["merged"] = json!(merged);
+        self.write_gh_state(&gh_state)
+    }
+
     /// All PRs as stored (state reflects the last query that observed a merge).
     pub fn stored_prs(&self) -> anyhow::Result<Vec<Value>> {
         Ok(self
@@ -429,6 +451,16 @@ impl TestRepo {
             .into_iter()
             .find(|pr| pr["number"] == json!(number))
             .with_context(|| format!("PR #{number} not found in fake gh state"))
+    }
+
+    pub fn stored_comments(&self, pr_number: u64) -> anyhow::Result<Vec<Value>> {
+        Ok(self
+            .read_gh_state()?
+            .get("comments")
+            .and_then(|comments| comments.get(pr_number.to_string()))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default())
     }
 
     /// Every recorded `gh` invocation's argv.
@@ -771,9 +803,12 @@ def resolve_state(state, pr):
 def pr_view(state, pr):
     head = remote_oid(pr["headRefName"]) or "headsha"
     base = remote_oid(pr["baseRefName"]) or "basesha"
+    resolved_state = resolve_state(state, pr)
+    merged = bool(pr.get("merged", False)) or resolved_state.upper() == "MERGED"
     return {
         "number": pr["number"],
-        "state": resolve_state(state, pr),
+        "state": resolved_state,
+        "merged": merged,
         "id": "PR_node_%d" % pr["number"],
         "headRefName": pr["headRefName"],
         "baseRefName": pr["baseRefName"],

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -639,9 +639,7 @@ pub fn stack_comment_body(
         .iter()
         .find(|(change_id, _, _, _, _)| *change_id == current_change_id)
     {
-        body.push_str(&format!(
-            "Check out this stack: `forklift get {number}`\n"
-        ));
+        body.push_str(&format!("Check out this stack: `forklift get {number}`\n"));
     }
     body.push_str("Pull/update this stack: `forklift sync`\n");
     body.push_str("Publish local edits: `forklift submit`\n");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -643,6 +643,182 @@ fn get_fetches_stack_from_comment_and_writes_cache() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn repair_prunes_merged_pr_from_stale_stack_comment() -> anyhow::Result<()> {
+    let repo = TestRepo::new("repair-stale-stack")?;
+    repo.init_main()?;
+    let open = repo.create_change("open", "open title", "open body")?;
+    let open_branch = branch_for("open-title", &open.change_id);
+    repo.set_bookmark(&open_branch, &open.commit_id)?;
+    repo.push_bookmark(&open_branch)?;
+
+    repo.jj(&["new", "main"])?;
+    let merged = repo.create_change("merged", "merged title", "merged body")?;
+    let merged_branch = branch_for("merged-title", &merged.change_id);
+    repo.set_bookmark(&merged_branch, &merged.commit_id)?;
+    repo.push_bookmark(&merged_branch)?;
+    repo.jj(&["bookmark", "set", "main", "-r", &merged.commit_id])?;
+    repo.push_bookmark("main")?;
+
+    repo.seed_pr(1, &open_branch, "main", "open title", "open body")?;
+    repo.seed_pr(5, &merged_branch, "main", "merged title", "merged body")?;
+    repo.set_pr_state(5, "CLOSED")?;
+    repo.set_pr_merged(5, true)?;
+    let rows = [
+        (
+            open.change_id.as_str(),
+            1u64,
+            open_branch.as_str(),
+            "main",
+            "open title",
+        ),
+        (
+            merged.change_id.as_str(),
+            5u64,
+            merged_branch.as_str(),
+            "main",
+            "merged title",
+        ),
+    ];
+    repo.seed_comment(1, 201, &common::stack_comment_body(&rows, &open.change_id))?;
+
+    let get_before = repo.run(&["get", "1"])?;
+    assert!(
+        !get_before.status.success(),
+        "stale get should fail before repair"
+    );
+    assert!(
+        stderr_of(&get_before).contains("PR #5 is CLOSED"),
+        "stderr:\n{}",
+        stderr_of(&get_before)
+    );
+
+    let repair_without_confirmation = repo.run(&["repair", "1"])?;
+    assert!(
+        !repair_without_confirmation.status.success(),
+        "non-interactive repair should require confirmation"
+    );
+    let stderr = stderr_of(&repair_without_confirmation);
+    assert!(
+        !stderr.contains("plan: repair stack comment"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("problems:\n  merged PRs still listed in stack comment: #5"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("open PRs remaining in stack"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("actions:\n  1. update stack comment on PR #1 to remove #5")
+            && stderr.contains("2. revalidate repaired stack comment topology"),
+        "stderr:\n{stderr}"
+    );
+    assert!(!stderr.contains("bytes)"), "stderr:\n{stderr}");
+    assert!(
+        stderr.contains("  2. revalidate repaired stack comment topology\n\nerror:"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("error: repair requires confirmation"),
+        "stderr:\n{stderr}"
+    );
+    let body_before_confirm = repo
+        .stored_comments(1)?
+        .first()
+        .and_then(|comment| comment["body"].as_str())
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        body_before_confirm.contains("/pull/5"),
+        "body:\n{body_before_confirm}"
+    );
+
+    let repair = repo.run(&["repair", "1", "--yes"])?;
+    assert_success("repair 1", &repair);
+    assert!(
+        stderr_of(&repair).contains("Finished repair"),
+        "stderr:\n{}",
+        stderr_of(&repair)
+    );
+    let comments = repo.stored_comments(1)?;
+    let body = comments
+        .first()
+        .and_then(|comment| comment["body"].as_str())
+        .unwrap_or_default();
+    assert!(body.contains("/pull/1"), "body:\n{body}");
+    assert!(!body.contains("/pull/5"), "body:\n{body}");
+
+    let get_after = repo.run(&["get", "1"])?;
+    assert_success("get 1 after repair", &get_after);
+    assert_eq!(
+        repo.bookmark_target("jj-stack/frozen/pr-1")?,
+        open.commit_id
+    );
+    Ok(())
+}
+
+#[test]
+fn repair_explains_closed_unmerged_pr_in_stack_comment() -> anyhow::Result<()> {
+    let repo = TestRepo::new("repair-closed-stack")?;
+    repo.init_main()?;
+    let open = repo.create_change("open", "open title", "open body")?;
+    let open_branch = branch_for("open-title", &open.change_id);
+    repo.set_bookmark(&open_branch, &open.commit_id)?;
+    repo.push_bookmark(&open_branch)?;
+
+    let closed = repo.create_change("closed", "closed title", "closed body")?;
+    let closed_branch = branch_for("closed-title", &closed.change_id);
+    repo.set_bookmark(&closed_branch, &closed.commit_id)?;
+    repo.push_bookmark(&closed_branch)?;
+
+    repo.seed_pr(1, &open_branch, "main", "open title", "open body")?;
+    repo.seed_pr(5, &closed_branch, "main", "closed title", "closed body")?;
+    repo.set_pr_state(5, "CLOSED")?;
+    let rows = [
+        (
+            open.change_id.as_str(),
+            1u64,
+            open_branch.as_str(),
+            "main",
+            "open title",
+        ),
+        (
+            closed.change_id.as_str(),
+            5u64,
+            closed_branch.as_str(),
+            "main",
+            "closed title",
+        ),
+    ];
+    repo.seed_comment(1, 201, &common::stack_comment_body(&rows, &open.change_id))?;
+
+    let repair = repo.run(&["repair", "1"])?;
+    assert!(
+        !repair.status.success(),
+        "repair should fail when a listed PR is closed but unmerged"
+    );
+    let stderr = stderr_of(&repair);
+    assert!(
+        stderr.contains("error: cannot repair stack comment automatically"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("reason:\n  PR #5 is CLOSED but not merged"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "resolution:\n  reopen or merge PR #5, or remove it from the stack comment manually, then run `forklift repair 1`"
+        ),
+        "stderr:\n{stderr}"
+    );
+    assert!(stderr.contains("state:     CLOSED"), "stderr:\n{stderr}");
+    Ok(())
+}
+
 // Secondary jj workspaces are NOT git worktrees — they have a `.jj/repo`
 // pointer to the primary's `.jj/repo` but no `.git`. `forklift` must therefore
 // route every `git` invocation to the backing colocated workspace, regardless

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -416,7 +416,7 @@ fn merge_refuses_open_frozen_dependency_below_owned_pr() -> anyhow::Result<()> {
     repo.push_bookmark(&top)?;
     repo.seed_pr(11, &bottom, "main", "change 1 title", "change 1 body")?;
     repo.seed_pr(12, &top, &bottom, "change 2 title", "change 2 body")?;
-    repo.set_bookmark("jj-stack/frozen/pr-11", &stack[0].commit_id)?;
+    repo.set_bookmark("forklift/frozen/pr-11", &stack[0].commit_id)?;
 
     let output = repo.run(&["merge"])?;
     assert!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -77,6 +77,39 @@ fn submit_dry_run_skips_cache_writes() -> anyhow::Result<()> {
 }
 
 #[test]
+fn pr_error_is_rendered_as_a_human_diagnostic() -> anyhow::Result<()> {
+    let repo = TestRepo::new("pr-error")?;
+    repo.init_main()?;
+    repo.create_change("change", "change title", "change body")?;
+
+    let output = repo.run(&["pr"])?;
+    assert!(!output.status.success(), "pr without a PR should fail");
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains("error: could not resolve PR for `@`"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("reason:\n  pr target `"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("resolution:\n  run `forklift submit --dry-run`"),
+        "stderr:\n{stderr}"
+    );
+    assert!(stderr.contains("details:"), "stderr:\n{stderr}");
+    assert!(
+        stderr.contains("phase:     resolve-pr"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("phase=resolve-pr object=@"),
+        "stderr:\n{stderr}"
+    );
+    Ok(())
+}
+
+#[test]
 fn two_change_submit_uses_parent_head_branch_base() -> anyhow::Result<()> {
     let repo = TestRepo::new("two-submit")?;
     repo.init_main()?;
@@ -366,6 +399,47 @@ fn clean_two_pr_merge_fast_forwards_trunk_and_merges_by_reachability() -> anyhow
             "PR #{number} should be merged"
         );
     }
+    Ok(())
+}
+
+#[test]
+fn merge_refuses_open_frozen_dependency_below_owned_pr() -> anyhow::Result<()> {
+    let repo = TestRepo::new("merge-open-frozen-dependency")?;
+    repo.init_main()?;
+    let main = repo.bookmark_target("main")?;
+    let stack = repo.create_linear_stack(2)?;
+    let bottom = branch_for("change-1-title", &stack[0].change_id);
+    let top = branch_for("change-2-title", &stack[1].change_id);
+    repo.set_bookmark(&bottom, &stack[0].commit_id)?;
+    repo.set_bookmark(&top, &stack[1].commit_id)?;
+    repo.push_bookmark(&bottom)?;
+    repo.push_bookmark(&top)?;
+    repo.seed_pr(11, &bottom, "main", "change 1 title", "change 1 body")?;
+    repo.seed_pr(12, &top, &bottom, "change 2 title", "change 2 body")?;
+    repo.set_bookmark("jj-stack/frozen/pr-11", &stack[0].commit_id)?;
+
+    let output = repo.run(&["merge"])?;
+    assert!(
+        !output.status.success(),
+        "merge should fail while lower dependency PR is open\nstdout:\n{}\nstderr:\n{}\nprs:\n{:#?}",
+        stdout_of(&output),
+        stderr_of(&output),
+        repo.stored_prs()?
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains("frozen dependency")
+            && stderr.contains("PR #11")
+            && stderr.contains("still open"),
+        "stderr:\n{stderr}"
+    );
+    assert_eq!(
+        repo.git_remote_branch_target("main")?,
+        main,
+        "merge must not advance trunk"
+    );
+    assert_eq!(repo.stored_pr(11)?["state"], json!("OPEN"));
+    assert_eq!(repo.stored_pr(12)?["state"], json!("OPEN"));
     Ok(())
 }
 

--- a/tests/real_github.rs
+++ b/tests/real_github.rs
@@ -52,7 +52,7 @@ impl RealGithubRepo {
                 "--disable-issues",
                 "--disable-wiki",
                 "--description",
-                "Disposable forklift E2E repository",
+                "Disposable Forklift E2E repository",
             ],
         )
         .with_context(|| {
@@ -63,7 +63,7 @@ impl RealGithubRepo {
 
         run_ok_in(&root, "jj", &["git", "init", "--colocate", "work"])?;
         run_ok_in(&work, "git", &["config", "user.email", "test@example.com"])?;
-        run_ok_in(&work, "git", &["config", "user.name", "forklift E2E"])?;
+        run_ok_in(&work, "git", &["config", "user.name", "Forklift E2E"])?;
         run_ok_in(
             &work,
             "jj",
@@ -72,7 +72,7 @@ impl RealGithubRepo {
         run_ok_in(
             &work,
             "jj",
-            &["config", "set", "--repo", "user.name", "forklift E2E"],
+            &["config", "set", "--repo", "user.name", "Forklift E2E"],
         )?;
         run_ok_in(
             &work,


### PR DESCRIPTION
[SLOP(gpt-5)] fix: label repair problems separately from actions

[SLOP(gpt-5)] fix: style repair plan headings

[SLOP(gpt-5)] fix: remove repair plan heading

[SLOP(gpt-5)] fix: revalidate repair with repair planner

[SLOP(gpt-5)] fix: show only repair problems in problems section

[SLOP(gpt-5)] fix: hide repair comment byte counts