### PR TITLE
[SLOP(gpt-5.5-minimal)] fix(merge): ignore superseded checks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,52 @@ pub fn tracked_stacks_revset(branch_prefix: &str) -> String {
     )
 }
 
+pub fn effective_status_checks(checks: &[serde_json::Value]) -> Vec<&serde_json::Value> {
+    let mut effective = Vec::<&serde_json::Value>::new();
+    for check in checks {
+        let identity = check_identity(check);
+        let timestamp = check_timestamp(check);
+        if let Some(existing_index) = effective
+            .iter()
+            .position(|existing| check_identity(existing) == identity)
+        {
+            let existing_timestamp = check_timestamp(effective[existing_index]);
+            let replace = match (timestamp, existing_timestamp) {
+                (Some(new), Some(old)) => new >= old,
+                (Some(_), None) => true,
+                (None, Some(_)) => false,
+                (None, None) => true,
+            };
+            if replace {
+                effective[existing_index] = check;
+            }
+        } else {
+            effective.push(check);
+        }
+    }
+    effective
+}
+
+fn check_identity(check: &serde_json::Value) -> String {
+    let workflow = check
+        .get("workflowName")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    let name = check
+        .get("name")
+        .or_else(|| check.get("context"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("<unknown>");
+    format!("{workflow}\t{name}")
+}
+
+fn check_timestamp(check: &serde_json::Value) -> Option<&str> {
+    check
+        .get("startedAt")
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| check.get("completedAt").and_then(serde_json::Value::as_str))
+}
+
 pub fn empty_string_to_none<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
     D: serde::Deserializer<'de>,

--- a/src/workflows/merge.rs
+++ b/src/workflows/merge.rs
@@ -1597,15 +1597,17 @@ pub(crate) fn validate_pr_ready_for_merge(
     Ok(())
 }
 
-/// Require every reported status check to pass before a direct squash merge.
+/// Require the latest reported status check per workflow/name to pass before a
+/// direct squash merge.
 ///
-/// Note: `statusCheckRollup` reports *all* checks on the PR, not only the ones
-/// branch protection marks as required. This intentionally fails closed — any
-/// failing or pending check blocks the merge — so the messages say "checks",
-/// not "required checks", to avoid implying we consulted branch protection.
+/// Note: `statusCheckRollup` reports checks on the PR, not only the ones branch
+/// protection marks as required. It can also retain superseded runs after
+/// GitHub Actions concurrency cancellation. Fail closed on the effective latest
+/// result for each check identity, so a stale cancelled run does not block a
+/// newer successful run for the same workflow/name.
 #[tracing::instrument(skip_all, fields(pr = pr_number))]
 pub(crate) fn validate_status_checks(pr_number: u64, checks: &[serde_json::Value]) -> Result<()> {
-    for check in checks {
+    for check in crate::effective_status_checks(checks) {
         let name = check_name(check);
         if let Some(state) = check.get("state").and_then(serde_json::Value::as_str) {
             if state != "SUCCESS" {

--- a/tests/status_checks.rs
+++ b/tests/status_checks.rs
@@ -1,0 +1,79 @@
+use forklift::effective_status_checks;
+use serde_json::json;
+
+#[test]
+fn status_checks_ignore_cancelled_run_superseded_by_success() {
+    let checks = vec![
+        json!({
+            "name": "auto-merge-dependency-updates",
+            "workflowName": "Auto Merge Dependency Updates",
+            "status": "COMPLETED",
+            "conclusion": "CANCELLED",
+            "completedAt": "2026-07-22T07:02:06Z"
+        }),
+        json!({
+            "name": "auto-merge-dependency-updates",
+            "workflowName": "Auto Merge Dependency Updates",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+            "completedAt": "2026-07-22T07:02:24Z"
+        }),
+    ];
+
+    let effective = effective_status_checks(&checks);
+
+    assert_eq!(effective.len(), 1);
+    assert_eq!(effective[0]["conclusion"], "SUCCESS");
+}
+
+#[test]
+fn status_checks_keep_newer_pending_run_with_null_completion_time() {
+    let checks = vec![
+        json!({
+            "name": "build",
+            "workflowName": "CI",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+            "startedAt": "2026-07-22T07:01:00Z",
+            "completedAt": "2026-07-22T07:04:00Z"
+        }),
+        json!({
+            "name": "build",
+            "workflowName": "CI",
+            "status": "IN_PROGRESS",
+            "conclusion": null,
+            "startedAt": "2026-07-22T07:03:00Z",
+            "completedAt": null
+        }),
+    ];
+
+    let effective = effective_status_checks(&checks);
+
+    assert_eq!(effective.len(), 1);
+    assert_eq!(effective[0]["status"], "IN_PROGRESS");
+}
+
+#[test]
+fn status_checks_keep_latest_duplicate_run_when_it_is_cancelled() {
+    let checks = vec![
+        json!({
+            "name": "auto-merge-dependency-updates",
+            "workflowName": "Auto Merge Dependency Updates",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+            "completedAt": "2026-07-22T07:02:06Z"
+        }),
+        json!({
+            "name": "auto-merge-dependency-updates",
+            "workflowName": "Auto Merge Dependency Updates",
+            "status": "COMPLETED",
+            "conclusion": "CANCELLED",
+            "completedAt": "2026-07-22T07:02:24Z"
+        }),
+    ];
+
+    let effective = effective_status_checks(&checks);
+
+    assert_eq!(effective.len(), 1);
+    assert_eq!(effective[0]["conclusion"], "CANCELLED");
+}


### PR DESCRIPTION
GitHub's status check rollup can retain cancelled workflow runs after newer attempts succeed, causing forklift merge to reject otherwise-ready PRs. This change evaluates only the latest run for each workflow and check identity using its start time with a completion-time fallback, while still blocking a latest pending, cancelled, or failing run; cargo fmt and targeted regression tests covering superseded success, latest cancellation, and pending runs pass.